### PR TITLE
Rank to level and Link to recycling station

### DIFF
--- a/apps/rubbish/src/app/account-stats/account-stats.component.html
+++ b/apps/rubbish/src/app/account-stats/account-stats.component.html
@@ -3,7 +3,7 @@
 </p>
 
 <ul>
-  <li>Your <strong>Current Rank</strong> is calculated based upon the number of points you have collected.</li>
+  <li>Your <strong>Current Level</strong> is calculated based upon the number of points you have collected.</li>
   <li>Your <strong>Total Points</strong> is the total sum of all your collected points.</li>
   <li>Your <strong>Total Images</strong> is the total sum of all your uploaded images (flagged orm otherwise).</li>
   <li>Your <strong>Total Rubbish</strong> is the caluclation of all rubbish detected by our systems.</li>

--- a/apps/rubbish/src/app/footer/footer.component.html
+++ b/apps/rubbish/src/app/footer/footer.component.html
@@ -1,5 +1,6 @@
 <footer>
   <div class="row justify-content-md-center">
+
     <div class="col-md-8">
       <img class="logo" width="200px" src="/assets/images/waterways-logo.png">
     </div>
@@ -10,6 +11,9 @@
       <a href=""><i class="fab fa-facebook"></i></a>
       <a href=""><i class="fab fa-twitter-square"></i></a>
       <a href=""><i class="fab fa-instagram"></i></a>
+    </div>
+    <div class="col-md-8">
+      <a href="https://www.containersforchange.com.au/where-can-i-return" style="color:white">Click here to find your closest container refund point</a>
     </div>
     <div class="col-md-8">
       <p class="copyright-line">&copy; Copyright {{today | date:'yyyy'}} Zen Tech | QUT Capstone Academic Project</p>

--- a/apps/rubbish/src/app/nav/nav.component.html
+++ b/apps/rubbish/src/app/nav/nav.component.html
@@ -22,7 +22,7 @@
 
       <span class="nav-divider"></span>
 
-      <span class="nav-link rank-info" *ngIf="loggedIn">Rank: {{currentRank}} | Points to next rank: {{xpNext}}</span>
+      <span class="nav-link rank-info" *ngIf="loggedIn">Level: {{currentRank}} | Points to next level: {{xpNext}}</span>
 
       <li class="nav-item pull-right">
         <a class="nav-link" (click)="isNavbarCollapsed = !isNavbarCollapsed" *ngIf="!loggedIn" routerLink="/login"><i class="fas fa-user mobile-hide"></i> Login</a>


### PR DESCRIPTION
Changed multiple instances of where we used rank to denote level to "level."

Missing one instance of the work rank being used on the image under the user's personal stats page.
Added link at the bottom of the page that links to the recycling station.